### PR TITLE
Update camera-source.ts to work in remote HomeKit connection

### DIFF
--- a/packages/homebridge-ring/camera-source.ts
+++ b/packages/homebridge-ring/camera-source.ts
@@ -275,8 +275,8 @@ class StreamingSessionWrapper {
               'libopus',
               '-frame_duration',
               request.audio.packet_time,
-              '-application',
-              'lowdelay',
+              //'-application', //commented to work in mobile context. 
+              //'lowdelay',
             ]
           : [
               // AAC-eld specific


### PR DESCRIPTION
This fix  `exited with code 1 and signal null` error 

When request.audio.packet_time is equal to 60 (remote on LTE/5G connection), ffmpeg fail and with -application voip or lowdelay mode.
In local requests network, the request.audio.packet_time is 20 and works fine.

I think this is the same error as we see in https://github.com/dgreif/ring/issues/1303